### PR TITLE
Type Error fix in guards1.enforce-guard-all

### DIFF
--- a/util/guards1/guards1.pact
+++ b/util/guards1/guards1.pact
@@ -22,6 +22,7 @@
   (defun enforce-guard-all:bool (guards:[guard])
     "Enforces all guards in GUARDS"
     (map (enforce-guard) guards)
+    true
   )
 
   (defun guard-any:guard (guards:[guard])

--- a/util/guards1/guards1.repl
+++ b/util/guards1/guards1.repl
@@ -1,5 +1,5 @@
 ;; guards1.repl
-(enforce-pact-version "3.5.0")
+(enforce-pact-version "4.6.0")
 
 (env-data
  { 'util-ns-users: ["util-ns-user"]

--- a/util/guards1/guards1.repl
+++ b/util/guards1/guards1.repl
@@ -6,14 +6,16 @@
  , 'util-ns-admin: ["util-ns-admin"]
  })
 (env-keys ["util-ns-user", "util-ns-admin"])
-
+(env-exec-config ["DisablePact44"])
 (begin-tx)
 (load "../util/util-ns.pact")
+(env-exec-config [])
 (commit-tx)
 
 
 (begin-tx)
 (load "guards1.pact")
+(typecheck "util.guards1")
 (commit-tx)
 
 (begin-tx)


### PR DESCRIPTION
Adds `true` at the end of the line to fix the type error
```  
(defun enforce-guard-all:bool (guards:[guard])
    "Enforces all guards in GUARDS"
    (map (enforce-guard) guards)
    true
  )```